### PR TITLE
Fixing the Compendium Scroll Bar to show all trophies in late game.

### DIFF
--- a/AugaUnity/Assets/Prefabs/Compendium.prefab
+++ b/AugaUnity/Assets/Prefabs/Compendium.prefab
@@ -2603,10 +2603,10 @@ RectTransform:
   m_Father: {fileID: 3371966454879683395}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 820}
+  m_SizeDelta: {x: 250, y: 1000}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &3587396161505599809
 MonoBehaviour:
@@ -3905,7 +3905,7 @@ PrefabInstance:
     - target: {fileID: 1148989287309648755, guid: 239553dd12c55e3469cf57f20fa7fa1c,
         type: 3}
       propertyPath: m_Size
-      value: 0.51829267
+      value: 0.33333334
       objectReference: {fileID: 0}
     - target: {fileID: 1148989287309648755, guid: 239553dd12c55e3469cf57f20fa7fa1c,
         type: 3}
@@ -3920,6 +3920,36 @@ PrefabInstance:
     - target: {fileID: 1838640914324707626, guid: 239553dd12c55e3469cf57f20fa7fa1c,
         type: 3}
       propertyPath: m_Padding.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2856497378761272106, guid: 239553dd12c55e3469cf57f20fa7fa1c,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2856497378761272106, guid: 239553dd12c55e3469cf57f20fa7fa1c,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2856497378761272106, guid: 239553dd12c55e3469cf57f20fa7fa1c,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2856497378761272106, guid: 239553dd12c55e3469cf57f20fa7fa1c,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 850
+      objectReference: {fileID: 0}
+    - target: {fileID: 2856497378761272106, guid: 239553dd12c55e3469cf57f20fa7fa1c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2856497378761272106, guid: 239553dd12c55e3469cf57f20fa7fa1c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3833124570446538995, guid: 239553dd12c55e3469cf57f20fa7fa1c,


### PR DESCRIPTION
Problem: The Compendium Trophy list was not showing all trophies in late game.

Fix: Made the TextItems prefab for Tutorials and Trophies to be stretch and set at a bottom of -1000 for trophies and -850 for Tutorial.

(cherry picked from commit b5c970f29a44a79abbf46bb80245559e36f2bde6)